### PR TITLE
Options to adjust on foot FOV and change camera speed.

### DIFF
--- a/source/SilentPatchScarface.cpp
+++ b/source/SilentPatchScarface.cpp
@@ -311,44 +311,38 @@ void OnInitializeHook()
 		{
 			// this 100.0 is used just for camera y variables so no problem overwriting it
 			auto y = get_pattern("B8 00 00 C8 42 C7 86 84 01 00 00", 1);
+			auto freeX = get_pattern("C7 86 84 01 00 00 00 00 48 43", 6);
+			auto gunX = get_pattern("C7 86 8C 01 00 00 00 00 16 43", 6);
+			auto rageX = get_pattern("C7 86 94 01 00 00 00 00 96 43", 6);
+			// "disable" script handler so that script doesnt change new values
+			// nulling strings seems to do the trick
+			auto RageSpeedY = get_pattern("52 61 67 65 53 70 65 65 64 59 00");
+			auto RageSpeedX = get_pattern("52 61 67 65 53 70 65 65 64 58 00");
+			auto FreeLookSpeedX = get_pattern("46 72 65 65 4C 6F 6F 6B 53 70 65 65 64 59 00");
+			auto FreeLookSpeedY = get_pattern("46 72 65 65 4C 6F 6F 6B 53 70 65 65 64 58 00 ");
+			auto GunSpeedY = get_pattern("47 75 6E 53 70 65 65 64 59 00"); 
+			auto GunSpeedX = get_pattern("47 75 6E 53 70 65 65 64 58 00"); 
+
+			Patch<char>(RageSpeedY, 0x00);
+			Patch<char>(RageSpeedX, 0x00);
+			Patch<char>(FreeLookSpeedX, 0x00);
+			Patch<char>(FreeLookSpeedY, 0x00);
+			Patch<char>(GunSpeedY, 0x00);
+			Patch<char>(GunSpeedX, 0x00);
+
+			// shared y
 			float origY = *(float*)(y);
 			Patch<float>(y, origY * camSpeedMultiplier);
 
-			// free look 
-			auto x = get_pattern("C7 86 84 01 00 00 00 00 48 43", 6);
-			float origX = *(float*)(x);
-			Patch<float>(x, origX * camSpeedMultiplier);
-
-			// aiming/gun
-			x = get_pattern("C7 86 8C 01 00 00 00 00 16 43", 6);
-			origX = *(float*)(x);
-			Patch<float>(x, origX * camSpeedMultiplier);
-
+			// freelook
+			float origX = *(float*)(freeX);
+			Patch<float>(freeX, origX * camSpeedMultiplier);
+			// aiming
+			origX = *(float*)(gunX);
+			Patch<float>(gunX, origX * camSpeedMultiplier);
 			// rage mode
-			x = get_pattern("C7 86 94 01 00 00 00 00 96 43", 6);
-			origX = *(float*)(x);
-			Patch<float>(x, origX * camSpeedMultiplier);
-
-			// "disable" script handler so that script doesnt change new values
-			// nulling strings seems to do the trick
-
-			auto varName = get_pattern("52 61 67 65 53 70 65 65 64 59 00"); // RageSpeedY
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("52 61 67 65 53 70 65 65 64 58 00"); // RageSpeedX
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("46 72 65 65 4C 6F 6F 6B 53 70 65 65 64 59 00"); // FreeLookSpeedX
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("46 72 65 65 4C 6F 6F 6B 53 70 65 65 64 58 00 "); // FreeLookSpeedY
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("47 75 6E 53 70 65 65 64 59 00"); // GunSpeedY
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("47 75 6E 53 70 65 65 64 58 00"); // GunSpeedX
-			Patch<char>(varName, 0x00);
+			origX = *(float*)(rageX);
+			Patch<float>(rageX, origX * camSpeedMultiplier);
 		}
 		TXN_CATCH();
 	}
@@ -361,28 +355,22 @@ void OnInitializeHook()
 			// TODO: vehicle?
 			// on foot
 			auto oldFOV = get_pattern("B8 00 00 70 42 89 86 64 01 00 00", 1);
+			auto ExteriorDefaultFOV = get_pattern("45 78 74 65 72 69 6F 72 44 65 66 61 75 6C 74 46"); 
+			auto ExteriorCombatFOV = get_pattern("45 78 74 65 72 69 6F 72 43 6F 6D 62 61 74 46 4F");
+			auto ExteriorLockedFOV = get_pattern("45 78 74 65 72 69 6F 72 4C 6F 63 6B 65 64 46 4F");
+			auto InteriorDefaultFOV = get_pattern("49 6E 74 65 72 69 6F 72 44 65 66 61 75 6C 74 46");
+			auto InteriorCombatFOV = get_pattern("49 6E 74 65 72 69 6F 72 43 6F 6D 62 61 74 46 4F");
+			auto InteriorLockedFOV = get_pattern("49 6E 74 65 72 69 6F 72 4C 6F 63 6B 65 64 46 4F");
+			auto RageFOV = get_pattern("52 61 67 65 46 4F 56 00"); 
+
 			Patch<float>(oldFOV, FOV);
-
-			auto varName = get_pattern("45 78 74 65 72 69 6F 72 44 65 66 61 75 6C 74 46"); // ExteriorDefaultFOV
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("45 78 74 65 72 69 6F 72 43 6F 6D 62 61 74 46 4F"); // ExteriorCombatFOV
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("45 78 74 65 72 69 6F 72 4C 6F 63 6B 65 64 46 4F"); // ExteriorLockedFOV
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("49 6E 74 65 72 69 6F 72 44 65 66 61 75 6C 74 46"); // InteriorDefaultFOV
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("49 6E 74 65 72 69 6F 72 43 6F 6D 62 61 74 46 4F"); // InteriorCombatFOV
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("49 6E 74 65 72 69 6F 72 4C 6F 63 6B 65 64 46 4F"); // InteriorLockedFOV
-			Patch<char>(varName, 0x00);
-
-			varName = get_pattern("52 61 67 65 46 4F 56 00"); // RageFOV
-			Patch<char>(varName, 0x00);
+			Patch<char>(ExteriorDefaultFOV, 0x00);
+			Patch<char>(ExteriorCombatFOV, 0x00);
+			Patch<char>(ExteriorLockedFOV, 0x00);
+			Patch<char>(InteriorDefaultFOV, 0x00);
+			Patch<char>(InteriorCombatFOV, 0x00);
+			Patch<char>(InteriorLockedFOV, 0x00);
+			Patch<char>(RageFOV, 0x00);
 		}
 		TXN_CATCH();
 	}


### PR DESCRIPTION
Scarface has slow camera movement which seems to be controlled by variables. Increasing the value makes camera feel more responsive.
Not using float for the multiplier value because increasing it by 0.25 or 0.50 is pointless.

Default camera:
https://user-images.githubusercontent.com/40604575/154246967-e6313af2-84b3-421a-891b-17a38ceca91f.mp4
10x:
https://user-images.githubusercontent.com/40604575/154247001-149a4b13-8e8b-42b8-81b2-07497899fed3.mp4


FOV on foot can also be changed. Vehicle FOV seems to be unaffected?